### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ dependencies {
     implementation("xyz.schwaab:avvylib:1.1.1")
 }
 ```
-* Or, Groovy `build.gradle.kts`
+* Or, Groovy `build.gradle`
 ```gradle
 dependencies {
     implementation "xyz.schwaab:avvylib:1.1.1"


### PR DESCRIPTION
Groovy based file extension build.gradle not build.gradle.kts